### PR TITLE
AWS + Nginx 환경에서 https 배포시 설정값 세팅

### DIFF
--- a/nginx/conf.d/nginx.blue.conf
+++ b/nginx/conf.d/nginx.blue.conf
@@ -32,6 +32,7 @@ http {
     		proxy_set_header    Host                $http_host;
     		proxy_set_header    X-Real-IP           $remote_addr;
     		proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+    		proxy_set_header    X-Forwarded-Proto   $scheme;
     	}
     }
 }

--- a/nginx/conf.d/nginx.green.conf
+++ b/nginx/conf.d/nginx.green.conf
@@ -32,6 +32,7 @@ http {
     		proxy_set_header    Host                $http_host;
     		proxy_set_header    X-Real-IP           $remote_addr;
     		proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+    		proxy_set_header    X-Forwarded-Proto   $scheme;
     	}
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,3 +62,9 @@ jwt:
 
 server:
   forward-headers-strategy: native
+  servlet:
+    session:
+      cookie:
+        http-only: true
+        secure: true
+        same-site: lax


### PR DESCRIPTION
## Summary
로컬에서는 잘 됐는데, 배포하고 테스트하니까 커스텀한 에러 페이지(쿠키 미입력)가 떴습니다.

## Describe your changes
AWS 환경에서 https 배포를 nginx로 했을 경우 중간에 nginx에서 넘겨주는 쿠키값을 애플리케이션이 인식해야 합니다.
따라서 nginx와 app의 관련설정을 바꿨습니다.

## Other information

## Issue number 

- Close #이슈번호
