### PR TITLE
nginx reload 하기 위한 설정 파일 이동 복사 작업 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -197,6 +197,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_KEY }}
           script: |
+            sudo cp -rf /home/ubuntu/chichi/nginx/conf.d/* /home/ubuntu/nginx/conf.d
             cd /home/ubuntu/chichi
             EXISTING_ACTIVE_COLOR=$(grep '^ACTIVE_COLOR=' .env | cut -d '=' -f2)
             echo "ACTIVE_COLOR=$EXISTING_ACTIVE_COLOR" >> .env.new


### PR DESCRIPTION
## Summary
nginx reload 하기 위한 설정 파일 이동 복사 작업 추가

## Describe your changes
nginx 설정 파일이 aws의 home/ubuntu/chichi/nginx/conf.d 폴더만 변경됐습니다.
nginx reload시 볼륨설정한 폴더를 참고하므로 home/ubuntu/nginx/conf.d 폴더로 복사했습니다.

## Other information

## Issue number 

- Close #이슈번호
