### PR TITLE
Song 엔티티 멤버필드명 변경: singer->uploader

### DIFF
--- a/src/main/java/com/example/chichi/domain/song/Song.java
+++ b/src/main/java/com/example/chichi/domain/song/Song.java
@@ -25,7 +25,7 @@ public class Song {
     private String title;
 
     @Column(nullable = false)
-    private String singer;
+    private String uploader;
 
     private String image;
 
@@ -39,16 +39,16 @@ public class Song {
     private LocalDateTime createdDate;
 
     @Builder
-    public Song(String title, String singer, String image, long videoId, String youtubeUrl) {
+    public Song(String title, String uploader, String image, long videoId, String youtubeUrl) {
         if (!StringUtils.hasText(title)) {
             throw new IllegalArgumentException("invalid title");
         }
         this.title = title;
 
-        if (!StringUtils.hasText(singer)) {
+        if (!StringUtils.hasText(uploader)) {
             throw new IllegalArgumentException("invalid singer");
         }
-        this.singer = singer;
+        this.uploader = uploader;
 
         // todo 기본 이미지 준비하기
         this.image = StringUtils.hasText(image) ? image : null;

--- a/src/main/java/com/example/chichi/domain/song/SongController.java
+++ b/src/main/java/com/example/chichi/domain/song/SongController.java
@@ -21,7 +21,7 @@ public class SongController {
     public ResponseEntity<ApiResponse<SongResponse>> addSong(@RequestBody @Valid AddSongRequest request) {
         SongResponse response = songService.addSong(
                 request.title(),
-                request.singer(),
+                request.uploader(),
                 request.image(),
                 request.videoId(),
                 request.youtubeUrl());

--- a/src/main/java/com/example/chichi/domain/song/SongRepositoryImpl.java
+++ b/src/main/java/com/example/chichi/domain/song/SongRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import static com.example.chichi.domain.song.QSong.song;
 
 import java.util.List;
 
@@ -14,21 +15,18 @@ public class SongRepositoryImpl implements SongRepositoryCustom {
 
     @Override
     public List<SongListResponse.SongSimpleResponse> findAllSongSimpleByIds(List<Long> songIds) {
-        QSong song = QSong.song;
-
         List<SongListResponse.SongSimpleResponse> result = jpaQueryFactory
                 .select(Projections.constructor(
                         SongListResponse.SongSimpleResponse.class,
                         song.id,
                         song.title,
-                        song.singer,
+                        song.uploader,
                         song.image,
-                        Expressions.constant(false)
+                        Expressions.asBoolean(false)
                 ))
                 .from(song)
                 .where(song.id.in(songIds))
                 .fetch();
-
         return result;
     }
 }

--- a/src/main/java/com/example/chichi/domain/song/SongService.java
+++ b/src/main/java/com/example/chichi/domain/song/SongService.java
@@ -26,7 +26,7 @@ public class SongService {
     private final int RECENT_SONG_LIMIT = 30;
 
     @Transactional
-    public SongResponse addSong(String title, String singer, String image,
+    public SongResponse addSong(String title, String uploader, String image,
                                 Long videoId, String youtubeUrl) {
         Optional<Song> optionalSong = songRepository.findByVideoId(videoId);
         if (optionalSong.isPresent()) {
@@ -34,7 +34,7 @@ public class SongService {
         } else {
             Song saved = songRepository.save(Song.builder()
                     .title(title)
-                    .singer(singer)
+                    .uploader(uploader)
                     .image(image)
                     .videoId(videoId)
                     .youtubeUrl(youtubeUrl)

--- a/src/main/java/com/example/chichi/domain/song/dto/AddSongRequest.java
+++ b/src/main/java/com/example/chichi/domain/song/dto/AddSongRequest.java
@@ -6,7 +6,7 @@ public record AddSongRequest(
         @NotNull
         String title,
         @NotNull
-        String singer,
+        String uploader,
         String image,
         @NotNull
         Long videoId,

--- a/src/main/java/com/example/chichi/domain/song/dto/SongListResponse.java
+++ b/src/main/java/com/example/chichi/domain/song/dto/SongListResponse.java
@@ -9,9 +9,9 @@ public record SongListResponse(
     public record SongSimpleResponse(
             Long songId,
             String title,
-            String singer,
+            String uploader,
             String image,
-            boolean liked
+            Boolean liked
     ) {
     }
 

--- a/src/main/java/com/example/chichi/domain/song/dto/SongResponse.java
+++ b/src/main/java/com/example/chichi/domain/song/dto/SongResponse.java
@@ -5,7 +5,7 @@ import com.example.chichi.domain.song.Song;
 public record SongResponse(
         long songId,
         String title,
-        String singer,
+        String uploader,
         String image,
         long videoId,
         String youtubeUrl
@@ -13,7 +13,7 @@ public record SongResponse(
     public SongResponse(Song song) {
         this(song.getId(),
                 song.getTitle(),
-                song.getSinger(),
+                song.getUploader(),
                 song.getImage(),
                 song.getVideoId(),
                 song.getYoutubeUrl());

--- a/src/main/java/com/example/chichi/domain/web/BotApiController.java
+++ b/src/main/java/com/example/chichi/domain/web/BotApiController.java
@@ -26,7 +26,7 @@ public class BotApiController {
         userService.checkUserByDiscordId(request.discordId());
         SongResponse recentPlayedSong = songService.addSong(
                 request.title(),
-                request.singer(),
+                request.uploader(),
                 request.image(),
                 request.videoId(),
                 request.youtubeUrl());

--- a/src/main/java/com/example/chichi/domain/web/SseService.java
+++ b/src/main/java/com/example/chichi/domain/web/SseService.java
@@ -33,7 +33,7 @@ public class SseService {
     public void broadcast(long discordId, SongResponse song) {
         SseEmitter emitter = emitters.get(discordId);
         SongListResponse.SongSimpleResponse data =
-                new SongListResponse.SongSimpleResponse(song.songId(), song.title(), song.singer(), song.image(),false);
+                new SongListResponse.SongSimpleResponse(song.songId(), song.title(), song.uploader(), song.image(),false);
 
         if (emitter != null) {
             try {

--- a/src/main/java/com/example/chichi/domain/web/dto/UpdateRecentSongRequest.java
+++ b/src/main/java/com/example/chichi/domain/web/dto/UpdateRecentSongRequest.java
@@ -6,7 +6,7 @@ public record UpdateRecentSongRequest(
         @NotNull
         String title,
         @NotNull
-        String singer,
+        String uploader,
         String image,
         @NotNull
         Long videoId,

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -125,7 +125,7 @@
           color: #474747;
         }
 
-        .song-singer {
+        .song-uploader {
           font-size: 14px;
           color: #D8C2B5;
         }
@@ -177,7 +177,7 @@
                 <img th:src="@{/images/basicProfileCat.png}" alt="앨범" class="album-cover"/>
                 <div class="song-info">
                     <div class="song-title" th:text="${record.title}">노래 제목</div>
-                    <div class="song-singer" th:text="${record.singer}">가수 이름</div>
+                    <div class="song-uploader" th:text="${record.uploader}">가수 이름</div>
                 </div>
             </div>
 
@@ -211,7 +211,7 @@
             <img src="${songImage}" alt="앨범" class="album-cover" />
             <div class="song-info">
                 <div class="song-title">${song.title}</div>
-                <div class="song-singer">${song.singer}</div>
+                <div class="song-uploader">${song.uploader}</div>
             </div>
         </div>
 

--- a/src/test/java/com/example/chichi/domain/song/SongControllerTest.java
+++ b/src/test/java/com/example/chichi/domain/song/SongControllerTest.java
@@ -65,14 +65,14 @@ class SongControllerTest {
     void addSong_success() throws Exception {
         //given
         String title = "test-title";
-        String singer = "test-singer";
+        String uploader = "test-uploader";
         String image = "test-image";
         long videoId = 1L;
         String url = "test-url";
-        AddSongRequest validRequest = new AddSongRequest(title, singer, image, videoId, url);
+        AddSongRequest validRequest = new AddSongRequest(title, uploader, image, videoId, url);
         long songId = 2L;
-        SongResponse response = new SongResponse(songId, title, singer, image, videoId, url);
-        given(songService.addSong(eq(title), eq(singer), eq(image), eq(videoId), eq(url))).willReturn(response);
+        SongResponse response = new SongResponse(songId, title, uploader, image, videoId, url);
+        given(songService.addSong(eq(title), eq(uploader), eq(image), eq(videoId), eq(url))).willReturn(response);
 
         //when, then
         mvc.perform(post("/api/songs")
@@ -93,9 +93,9 @@ class SongControllerTest {
     void addSong_fail() throws Exception {
         //given
         String title = "test-title";
-        String singer = "test-singer";
+        String uploader = "test-uploader";
         String url = "test-url";
-        AddSongRequest validRequest = new AddSongRequest(title, singer, null, null, url);
+        AddSongRequest validRequest = new AddSongRequest(title, uploader, null, null, url);
 
         //when, then
         mvc.perform(post("/api/songs")
@@ -131,7 +131,7 @@ class SongControllerTest {
     void getSong() throws Exception {
         //given
         long songId = 1L;
-        SongResponse response = new SongResponse(songId, "test-title", "test-singer", null, 2L, "test-url");
+        SongResponse response = new SongResponse(songId, "test-title", "test-uploader", null, 2L, "test-url");
         given(songService.getSong(eq(songId))).willReturn(response);
         //when, then
         mvc.perform(get("/api/songs/{song-id}", songId)
@@ -206,9 +206,9 @@ class SongControllerTest {
     void getRecentPlayedSongList() throws Exception {
         //given
         List<SongListResponse.SongSimpleResponse> list =
-                List.of(new SongListResponse.SongSimpleResponse(1L, "test-title1", "test-singer1", "test-image1", false),
-                        new SongListResponse.SongSimpleResponse(2L, "test-title2", "test-singer2", "test-image2", false),
-                        new SongListResponse.SongSimpleResponse(3L, "test-title3", "test-singer3", "test-image3", false));
+                List.of(new SongListResponse.SongSimpleResponse(1L, "test-title1", "test-uploader1", "test-image1", false),
+                        new SongListResponse.SongSimpleResponse(2L, "test-title2", "test-uploader2", "test-image2", false),
+                        new SongListResponse.SongSimpleResponse(3L, "test-title3", "test-uploader3", "test-image3", false));
         SongListResponse response = new SongListResponse(list, new SongListResponse.Meta(3, 30));
         given(songService.getRecentPlayedSongList(eq(TEST_AUTH_USER_ID))).willReturn(response);
         //when, then

--- a/src/test/java/com/example/chichi/domain/song/SongRepositoryTest.java
+++ b/src/test/java/com/example/chichi/domain/song/SongRepositoryTest.java
@@ -46,7 +46,7 @@ class SongRepositoryTest {
                 .forEach(e -> songRepository.save(
                         Song.builder()
                                 .title("test-title")
-                                .singer("test-singer")
+                                .uploader("test-uploader")
                                 .videoId(e)
                                 .youtubeUrl("test-url")
                                 .build()

--- a/src/test/java/com/example/chichi/domain/song/SongServiceTest.java
+++ b/src/test/java/com/example/chichi/domain/song/SongServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.List;
 import java.util.Optional;
 
-import static com.example.chichi.global.exception.ExceptionType.DUPLICATE_SONG;
 import static com.example.chichi.global.exception.ExceptionType.SONG_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -44,7 +43,7 @@ class SongServiceTest {
         long videoId = 1L;
         Song savedSong = Song.builder()
                 .title("test-title")
-                .singer("test-singer")
+                .uploader("test-uploader")
                 .videoId(videoId)
                 .youtubeUrl("test-url")
                 .build();
@@ -52,7 +51,7 @@ class SongServiceTest {
         given(songRepository.findByVideoId(eq(videoId))).willReturn(Optional.of(savedSong));
 
         //when
-        SongResponse response = songService.addSong("test-title", "test-singer", null, videoId, "test-url");
+        SongResponse response = songService.addSong("test-title", "test-uploader", null, videoId, "test-url");
 
         //then
         assertThat(response.videoId()).isEqualTo(videoId);
@@ -65,7 +64,7 @@ class SongServiceTest {
         long videoId = 1L;
         Song savedSong = Song.builder()
                 .title("test-title")
-                .singer("test-singer")
+                .uploader("test-uploader")
                 .videoId(videoId)
                 .youtubeUrl("test-url")
                 .build();
@@ -73,7 +72,7 @@ class SongServiceTest {
         given(songRepository.findByVideoId(eq(videoId))).willReturn(Optional.empty());
         given(songRepository.save(any())).willReturn(savedSong);
         //when, then
-        SongResponse response = songService.addSong("test-title", "test-singer", null, videoId, "test-url");
+        SongResponse response = songService.addSong("test-title", "test-uploader", null, videoId, "test-url");
 
         assertThat(response.videoId()).isEqualTo(videoId);
     }
@@ -101,7 +100,7 @@ class SongServiceTest {
 
         Song song = Song.builder()
                 .title("test-title")
-                .singer("test-singer")
+                .uploader("test-uploader")
                 .videoId(videoId)
                 .youtubeUrl(url)
                 .build();
@@ -138,7 +137,7 @@ class SongServiceTest {
         long songId = 2L;
         Song song = Song.builder()
                 .title("test-title")
-                .singer("test-singer")
+                .uploader("test-uploader")
                 .videoId(videoId)
                 .youtubeUrl("test-url").build();
         ReflectionTestUtils.setField(song, "id", songId);
@@ -209,14 +208,14 @@ class SongServiceTest {
         List<Long> recentSongs = List.of(song1Id, song2Id);
         given(recentPlayedSongRepository.findAllRecentPlayedSongByDiscordIdLatest(eq(String.valueOf(discordId)))).willReturn(recentSongs);
 
-        Song song1 = Song.builder().title("title").singer("singer").videoId(2L).youtubeUrl("url").build();
+        Song song1 = Song.builder().title("title").uploader("uploader").videoId(2L).youtubeUrl("url").build();
         ReflectionTestUtils.setField(song1, "id", song1Id);
-        Song song2 = Song.builder().title("title").singer("singer").videoId(3L).youtubeUrl("url").build();
+        Song song2 = Song.builder().title("title").uploader("uploader").videoId(3L).youtubeUrl("url").build();
         ReflectionTestUtils.setField(song2, "id", song2Id);
 
         List<SongListResponse.SongSimpleResponse> simpleSongs = List.of(
-                new SongListResponse.SongSimpleResponse(song1.getId(), song1.getTitle(),song1.getSinger(), song1.getImage(), false),
-                new SongListResponse.SongSimpleResponse(song2.getId(), song2.getTitle(),song2.getSinger(), song2.getImage(), false));
+                new SongListResponse.SongSimpleResponse(song1.getId(), song1.getTitle(), song1.getUploader(), song1.getImage(), false),
+                new SongListResponse.SongSimpleResponse(song2.getId(), song2.getTitle(), song2.getUploader(), song2.getImage(), false));
         given(songRepository.findAllSongSimpleByIds(eq(recentSongs))).willReturn(simpleSongs);
 
         //when

--- a/src/test/java/com/example/chichi/domain/web/BotApiControllerTest.java
+++ b/src/test/java/com/example/chichi/domain/web/BotApiControllerTest.java
@@ -51,21 +51,21 @@ class BotApiControllerTest {
     void updateRecentSongList() throws Exception {
         //given
         String title = "test-title";
-        String singer = "test-singer";
+        String uploader = "test-uploader";
         long videoId = 1L;
         String url = "test-url";
         long discordId = 2L;
         Song song = Song.builder()
                 .title(title)
-                .singer(singer)
+                .uploader(uploader)
                 .videoId(videoId)
                 .youtubeUrl(url)
                 .build();
         ReflectionTestUtils.setField(song, "id", 3L);
-        UpdateRecentSongRequest request = new UpdateRecentSongRequest(title, singer, null, videoId, url, discordId);
+        UpdateRecentSongRequest request = new UpdateRecentSongRequest(title, uploader, null, videoId, url, discordId);
 
         SongResponse recentSong = new SongResponse(song);
-        given(songService.addSong(eq(title), eq(singer), eq(null), eq(videoId), eq(url))).willReturn(recentSong);
+        given(songService.addSong(eq(title), eq(uploader), eq(null), eq(videoId), eq(url))).willReturn(recentSong);
 
         //when, then
         mvc.perform(post("/api/bot/recent-played-song")
@@ -89,18 +89,18 @@ class BotApiControllerTest {
     void updateRecentSongList_not_user_fail() throws Exception {
         //given
         String title = "test-title";
-        String singer = "test-singer";
+        String uploader = "test-uploader";
         long videoId = 1L;
         String url = "test-url";
         long discordId = 2L;
         Song song = Song.builder()
                 .title(title)
-                .singer(singer)
+                .uploader(uploader)
                 .videoId(videoId)
                 .youtubeUrl(url)
                 .build();
         ReflectionTestUtils.setField(song, "id", 3L);
-        UpdateRecentSongRequest request = new UpdateRecentSongRequest(title, singer, null, videoId, url, discordId);
+        UpdateRecentSongRequest request = new UpdateRecentSongRequest(title, uploader, null, videoId, url, discordId);
 
         doThrow(new ApiException(USER_NOT_FOUND)).when(userService).checkUserByDiscordId(eq(discordId));
 


### PR DESCRIPTION
## Summary
Song 엔티티 멤버필드명 변경: singer->uploader

## Describe your changes
유튜브 베이스로 노래를 가져오기 때문에 제목이 다들 제멋대로입니다.
규칙없는 문자열 제목에서 노래명과 가수명을 가져오는 건 어렵습니다. 
원래는 AI를 써서 분류하려고 했기 때문에 문제가 될 것이라곤 생각안했습니다.
그런데 생각해보니 누구는 "아이유/좋은날" 을 "IU/좋은날" 이렇게 적을 수 있습니다. 
즉 아이유과 IU가 같은 사람임을 인지시키는 것도 추가 작업이 될 예정이 틀림없었습니다.
게다가 하나의 노래를 여러개의 버전으로 작업해서 올리기 때문에 제목과 가수가 같다고 다른 곡으로 매칭이 되면 안됐습니다.
또한 요새는 AI로 자신만의 노래를 만드는 경우도 생겼기 때문에 제목에서 가져오는 것이 아니라 그 영상을 올린 업로더가 가수가 됩니다.
그래서 멤버필드명을 uploader로 바꿔야 했습니다.

즉 원래는 지니뮤직을 생각하며 작업을 했다면 이제는 유튜브 프리미엄 뮤직을 생각하며 작업을 할 예정입니다.

## Other information

## Issue number 

- Close #26 
