### PR TITLE
Song 엔티티 youtubeUrl 멤버필드 삭제

### DIFF
--- a/src/main/java/com/example/chichi/domain/song/Song.java
+++ b/src/main/java/com/example/chichi/domain/song/Song.java
@@ -32,14 +32,11 @@ public class Song {
     @Column(nullable = false, name = "video_id")
     private long videoId;
 
-    @Column(nullable = false, name = "youtube_url")
-    private String youtubeUrl;
-
     @CreatedDate
     private LocalDateTime createdDate;
 
     @Builder
-    public Song(String title, String uploader, String image, long videoId, String youtubeUrl) {
+    public Song(String title, String uploader, String image, long videoId) {
         if (!StringUtils.hasText(title)) {
             throw new IllegalArgumentException("invalid title");
         }
@@ -57,10 +54,5 @@ public class Song {
             throw new IllegalArgumentException("invalid videoId");
         }
         this.videoId = videoId;
-
-        if (!StringUtils.hasText(youtubeUrl)) {
-            throw new IllegalArgumentException("invalid youtubeUrl");
-        }
-        this.youtubeUrl = youtubeUrl;
     }
 }

--- a/src/main/java/com/example/chichi/domain/song/SongController.java
+++ b/src/main/java/com/example/chichi/domain/song/SongController.java
@@ -23,8 +23,7 @@ public class SongController {
                 request.title(),
                 request.uploader(),
                 request.image(),
-                request.videoId(),
-                request.youtubeUrl());
+                request.videoId());
         return ResponseEntity.ok(
                 ApiResponse.ok("곡 등록에 성공하였습니다.", response)
         );

--- a/src/main/java/com/example/chichi/domain/song/SongService.java
+++ b/src/main/java/com/example/chichi/domain/song/SongService.java
@@ -27,7 +27,7 @@ public class SongService {
 
     @Transactional
     public SongResponse addSong(String title, String uploader, String image,
-                                Long videoId, String youtubeUrl) {
+                                Long videoId) {
         Optional<Song> optionalSong = songRepository.findByVideoId(videoId);
         if (optionalSong.isPresent()) {
             return new SongResponse(optionalSong.get());
@@ -37,7 +37,6 @@ public class SongService {
                     .uploader(uploader)
                     .image(image)
                     .videoId(videoId)
-                    .youtubeUrl(youtubeUrl)
                     .build()
             );
             return new SongResponse(saved);

--- a/src/main/java/com/example/chichi/domain/song/dto/AddSongRequest.java
+++ b/src/main/java/com/example/chichi/domain/song/dto/AddSongRequest.java
@@ -9,8 +9,6 @@ public record AddSongRequest(
         String uploader,
         String image,
         @NotNull
-        Long videoId,
-        @NotNull
-        String youtubeUrl
+        Long videoId
 ) {
 }

--- a/src/main/java/com/example/chichi/domain/song/dto/SongResponse.java
+++ b/src/main/java/com/example/chichi/domain/song/dto/SongResponse.java
@@ -7,15 +7,13 @@ public record SongResponse(
         String title,
         String uploader,
         String image,
-        long videoId,
-        String youtubeUrl
+        long videoId
 ) {
     public SongResponse(Song song) {
         this(song.getId(),
                 song.getTitle(),
                 song.getUploader(),
                 song.getImage(),
-                song.getVideoId(),
-                song.getYoutubeUrl());
+                song.getVideoId());
     }
 }

--- a/src/main/java/com/example/chichi/domain/web/BotApiController.java
+++ b/src/main/java/com/example/chichi/domain/web/BotApiController.java
@@ -28,8 +28,7 @@ public class BotApiController {
                 request.title(),
                 request.uploader(),
                 request.image(),
-                request.videoId(),
-                request.youtubeUrl());
+                request.videoId());
         songService.addRecentPlayedSong(request.discordId(), recentPlayedSong.songId());
         sseService.broadcast(request.discordId(), recentPlayedSong);
         return ResponseEntity.ok(

--- a/src/main/java/com/example/chichi/domain/web/dto/UpdateRecentSongRequest.java
+++ b/src/main/java/com/example/chichi/domain/web/dto/UpdateRecentSongRequest.java
@@ -11,8 +11,6 @@ public record UpdateRecentSongRequest(
         @NotNull
         Long videoId,
         @NotNull
-        String youtubeUrl,
-        @NotNull
         Long discordId
 ) {
 }

--- a/src/test/java/com/example/chichi/domain/song/SongControllerTest.java
+++ b/src/test/java/com/example/chichi/domain/song/SongControllerTest.java
@@ -68,11 +68,10 @@ class SongControllerTest {
         String uploader = "test-uploader";
         String image = "test-image";
         long videoId = 1L;
-        String url = "test-url";
-        AddSongRequest validRequest = new AddSongRequest(title, uploader, image, videoId, url);
+        AddSongRequest validRequest = new AddSongRequest(title, uploader, image, videoId);
         long songId = 2L;
-        SongResponse response = new SongResponse(songId, title, uploader, image, videoId, url);
-        given(songService.addSong(eq(title), eq(uploader), eq(image), eq(videoId), eq(url))).willReturn(response);
+        SongResponse response = new SongResponse(songId, title, uploader, image, videoId);
+        given(songService.addSong(eq(title), eq(uploader), eq(image), eq(videoId))).willReturn(response);
 
         //when, then
         mvc.perform(post("/api/songs")
@@ -94,8 +93,7 @@ class SongControllerTest {
         //given
         String title = "test-title";
         String uploader = "test-uploader";
-        String url = "test-url";
-        AddSongRequest validRequest = new AddSongRequest(title, uploader, null, null, url);
+        AddSongRequest validRequest = new AddSongRequest(title, uploader, null, null);
 
         //when, then
         mvc.perform(post("/api/songs")
@@ -131,7 +129,7 @@ class SongControllerTest {
     void getSong() throws Exception {
         //given
         long songId = 1L;
-        SongResponse response = new SongResponse(songId, "test-title", "test-uploader", null, 2L, "test-url");
+        SongResponse response = new SongResponse(songId, "test-title", "test-uploader", null, 2L);
         given(songService.getSong(eq(songId))).willReturn(response);
         //when, then
         mvc.perform(get("/api/songs/{song-id}", songId)

--- a/src/test/java/com/example/chichi/domain/song/SongRepositoryTest.java
+++ b/src/test/java/com/example/chichi/domain/song/SongRepositoryTest.java
@@ -48,7 +48,6 @@ class SongRepositoryTest {
                                 .title("test-title")
                                 .uploader("test-uploader")
                                 .videoId(e)
-                                .youtubeUrl("test-url")
                                 .build()
                 ));
 

--- a/src/test/java/com/example/chichi/domain/song/SongServiceTest.java
+++ b/src/test/java/com/example/chichi/domain/song/SongServiceTest.java
@@ -45,13 +45,12 @@ class SongServiceTest {
                 .title("test-title")
                 .uploader("test-uploader")
                 .videoId(videoId)
-                .youtubeUrl("test-url")
                 .build();
         ReflectionTestUtils.setField(savedSong, "id", 2L);
         given(songRepository.findByVideoId(eq(videoId))).willReturn(Optional.of(savedSong));
 
         //when
-        SongResponse response = songService.addSong("test-title", "test-uploader", null, videoId, "test-url");
+        SongResponse response = songService.addSong("test-title", "test-uploader", null, videoId);
 
         //then
         assertThat(response.videoId()).isEqualTo(videoId);
@@ -66,13 +65,12 @@ class SongServiceTest {
                 .title("test-title")
                 .uploader("test-uploader")
                 .videoId(videoId)
-                .youtubeUrl("test-url")
                 .build();
         ReflectionTestUtils.setField(savedSong, "id", 2L);
         given(songRepository.findByVideoId(eq(videoId))).willReturn(Optional.empty());
         given(songRepository.save(any())).willReturn(savedSong);
         //when, then
-        SongResponse response = songService.addSong("test-title", "test-uploader", null, videoId, "test-url");
+        SongResponse response = songService.addSong("test-title", "test-uploader", null, videoId);
 
         assertThat(response.videoId()).isEqualTo(videoId);
     }
@@ -102,7 +100,6 @@ class SongServiceTest {
                 .title("test-title")
                 .uploader("test-uploader")
                 .videoId(videoId)
-                .youtubeUrl(url)
                 .build();
         ReflectionTestUtils.setField(song, "id", songId);
         given(songRepository.findById(eq(songId))).willReturn(Optional.of(song));
@@ -113,7 +110,6 @@ class SongServiceTest {
         //then
         assertThat(response.songId()).isEqualTo(songId);
         assertThat(response.videoId()).isEqualTo(videoId);
-        assertThat(response.youtubeUrl()).isEqualTo(url);
     }
 
     @Test
@@ -139,7 +135,7 @@ class SongServiceTest {
                 .title("test-title")
                 .uploader("test-uploader")
                 .videoId(videoId)
-                .youtubeUrl("test-url").build();
+                .build();
         ReflectionTestUtils.setField(song, "id", songId);
         given(songRepository.findByVideoId(eq(videoId))).willReturn(Optional.of(song));
 
@@ -208,9 +204,9 @@ class SongServiceTest {
         List<Long> recentSongs = List.of(song1Id, song2Id);
         given(recentPlayedSongRepository.findAllRecentPlayedSongByDiscordIdLatest(eq(String.valueOf(discordId)))).willReturn(recentSongs);
 
-        Song song1 = Song.builder().title("title").uploader("uploader").videoId(2L).youtubeUrl("url").build();
+        Song song1 = Song.builder().title("title").uploader("uploader").videoId(2L).build();
         ReflectionTestUtils.setField(song1, "id", song1Id);
-        Song song2 = Song.builder().title("title").uploader("uploader").videoId(3L).youtubeUrl("url").build();
+        Song song2 = Song.builder().title("title").uploader("uploader").videoId(3L).build();
         ReflectionTestUtils.setField(song2, "id", song2Id);
 
         List<SongListResponse.SongSimpleResponse> simpleSongs = List.of(

--- a/src/test/java/com/example/chichi/domain/web/BotApiControllerTest.java
+++ b/src/test/java/com/example/chichi/domain/web/BotApiControllerTest.java
@@ -53,19 +53,17 @@ class BotApiControllerTest {
         String title = "test-title";
         String uploader = "test-uploader";
         long videoId = 1L;
-        String url = "test-url";
         long discordId = 2L;
         Song song = Song.builder()
                 .title(title)
                 .uploader(uploader)
                 .videoId(videoId)
-                .youtubeUrl(url)
                 .build();
         ReflectionTestUtils.setField(song, "id", 3L);
-        UpdateRecentSongRequest request = new UpdateRecentSongRequest(title, uploader, null, videoId, url, discordId);
+        UpdateRecentSongRequest request = new UpdateRecentSongRequest(title, uploader, null, videoId, discordId);
 
         SongResponse recentSong = new SongResponse(song);
-        given(songService.addSong(eq(title), eq(uploader), eq(null), eq(videoId), eq(url))).willReturn(recentSong);
+        given(songService.addSong(eq(title), eq(uploader), eq(null), eq(videoId))).willReturn(recentSong);
 
         //when, then
         mvc.perform(post("/api/bot/recent-played-song")
@@ -91,16 +89,14 @@ class BotApiControllerTest {
         String title = "test-title";
         String uploader = "test-uploader";
         long videoId = 1L;
-        String url = "test-url";
         long discordId = 2L;
         Song song = Song.builder()
                 .title(title)
                 .uploader(uploader)
                 .videoId(videoId)
-                .youtubeUrl(url)
                 .build();
         ReflectionTestUtils.setField(song, "id", 3L);
-        UpdateRecentSongRequest request = new UpdateRecentSongRequest(title, uploader, null, videoId, url, discordId);
+        UpdateRecentSongRequest request = new UpdateRecentSongRequest(title, uploader, null, videoId, discordId);
 
         doThrow(new ApiException(USER_NOT_FOUND)).when(userService).checkUserByDiscordId(eq(discordId));
 

--- a/src/test/java/com/example/chichi/domain/web/SseIntegrationTest.java
+++ b/src/test/java/com/example/chichi/domain/web/SseIntegrationTest.java
@@ -94,7 +94,7 @@ public class SseIntegrationTest {
                 .then(() -> {
                     sseService.broadcast(
                             discordId,
-                            new SongResponse(3L, title, "singer", null, 4L, "url"));
+                            new SongResponse(3L, title, "singer", null, 4L));
                 })
                 .expectNextMatches(event ->
                         event.event().equals("recentSongUpdate") && event.data().contains(title))
@@ -129,7 +129,7 @@ public class SseIntegrationTest {
                 .then(() -> {
                     sseService.broadcast(
                             different_discordId,
-                            new SongResponse(3L, title, "singer", null, 4L, "url"));
+                            new SongResponse(3L, title, "singer", null, 4L));
                 })
                 .expectNoEvent(Duration.ofSeconds(3))
                 .thenCancel()


### PR DESCRIPTION
## Summary
Song 엔티티 youtubeUrl 멤버필드를 삭제했습니다.

## Describe your changes
videoId만 있으면 url을 만들 수 있기 때문에 데이터베이스 공간 절약을 위해 삭제했습니다.

## Other information

## Issue number 

- Close #28 
